### PR TITLE
Add structured logging as conditional toolchain category

### DIFF
--- a/src/ADAPTING.md
+++ b/src/ADAPTING.md
@@ -91,6 +91,7 @@ Multiple developers, real users. Coordination, review, and controlled rollout al
 | Release notes             | Tag message                | Required                                            | Required                                      |
 | Hotfixes                  | Fix on `main`              | Branch from tag                                     | Branch from tag + review                      |
 | **Toolchain**             | Formatter + linter minimum | Full (formatter, linter, type checker, test runner) | Full, CI-enforced                             |
+| **Structured logging**    | Not required               | Required for Class 2+                               | Required, CI-enforced                         |
 | **Golden commands**       | `fmt` + `test` minimum     | All four (`fmt`, `lint`, `typecheck`, `test`, `ci`) | All, CI-enforced                              |
 | **Agent constraints**     | CLAUDE.md with basic rules | CLAUDE.md + toolchain config                        | CLAUDE.md + toolchain config + review gates   |
 | **Knowledge persistence** | README, inline comments    | README + ADRs for significant decisions             | README + ADRs + persistent plans + milestones |
@@ -122,12 +123,12 @@ A common real-world pattern: a team where some members are experienced engineers
 
 Orthogonal to both tier and product type. Project class describes durability and quality requirements. See [Principles](PRINCIPLES.md) for the full classification model.
 
-| Class                      | Name                             | Toolchain                  | Issues   | CI       | Knowledge                        |
-| -------------------------- | -------------------------------- | -------------------------- | -------- | -------- | -------------------------------- |
-| **0 — Scratchpad**         | Throwaway experiments            | Formatter only             | No       | No       | None required                    |
-| **1 — Prototype**          | Real structure, limited lifespan | Formatter + linter + tests | Optional | Optional | README                           |
-| **2 — Product Seed**       | Intended to ship                 | Full toolchain             | Required | Required | README + ADRs                    |
-| **3 — Long-Lived Product** | Durability matters               | Full toolchain, enforced   | Required | Required | README + ADRs + persistent plans |
+| Class                      | Name                             | Toolchain                                     | Issues   | CI       | Knowledge                        |
+| -------------------------- | -------------------------------- | --------------------------------------------- | -------- | -------- | -------------------------------- |
+| **0 — Scratchpad**         | Throwaway experiments            | Formatter only                                | No       | No       | None required                    |
+| **1 — Prototype**          | Real structure, limited lifespan | Formatter + linter + tests                    | Optional | Optional | README                           |
+| **2 — Product Seed**       | Intended to ship                 | Full toolchain + structured logging           | Required | Required | README + ADRs                    |
+| **3 — Long-Lived Product** | Durability matters               | Full toolchain + structured logging, enforced | Required | Required | README + ADRs + persistent plans |
 
 ### Class and Tier Together
 

--- a/src/GLOSSARY.md
+++ b/src/GLOSSARY.md
@@ -167,7 +167,11 @@ These three identifiers are related but not identical:
 
 ### Toolchain
 
-The configured set of formatter, linter, type checker, and test runner for a project. The enforcement layer that turns principles into automated checks.
+The configured set of formatter, linter, type checker, and test runner for a project, plus conditional categories (such as structured logging) based on project class. The enforcement layer that turns principles into automated checks.
+
+### Structured Logging
+
+A logging convention where output is machine-parseable (typically JSON), leveled (debug, info, warn, error), and produced through a configured logger rather than raw print statements. In UEM, structured logging is a conditional toolchain category — mandatory for Class 2+ projects. Enforcement is mediated through linter rules, not a separate golden command.
 
 ### Golden Command
 

--- a/src/QUICKSTART-AUDIT.md
+++ b/src/QUICKSTART-AUDIT.md
@@ -94,7 +94,7 @@ Compare the current state against what the identified tier and class combination
 requires, according to UEM. Organize by module in the brownfield adoption order:
 
 1. **Knowledge** — project map, agent instructions, ADRs, documentation
-2. **Construction** — formatter, linter, type checker, test runner, golden commands, validation surface
+2. **Construction** — formatter, linter, type checker, test runner, structured logging (Class 2+), golden commands, validation surface
 3. **Change Management** — issue tracking, commit conventions, branch strategy, PR workflow
 4. **Delivery** — CI pipeline, tagged releases, artifact management, environments
 

--- a/src/modules/construction/README.md
+++ b/src/modules/construction/README.md
@@ -136,7 +136,7 @@ The order matters. Scaffolding is not a checklist — it is a sequence with a ga
 
 ```text
 1. Create project structure     — directories, entry points, README
-2. Configure toolchain          — formatter, linter, type checker, test runner
+2. Configure toolchain          — formatter, linter, type checker, test runner; for Class 2+, structured logging library and linter rules banning raw output
 3. Wire golden commands         — just fmt, just lint, just typecheck, just test, just ci
 4. Verify: just ci passes       — on a clean project with no application code
 5. Wire CI                      — CI runs the same golden commands
@@ -198,3 +198,4 @@ From the [Principles](../../PRINCIPLES.md):
 2. **Use tools for rules.** Formatters, linters, type checkers, test runners — not prompts.
 3. **Small bounded tasks beat giant one-shot generations.** The execution loop enforces this.
 4. **Validation is mandatory, not optional.** Golden commands are the gate.
+5. **Observability starts at construction.** Structured logging is enforced during construction through linter rules, not deferred to delivery. See [Toolchain — Conditional Categories](TOOLCHAIN.md#conditional-categories).

--- a/src/modules/construction/TOOLCHAIN.md
+++ b/src/modules/construction/TOOLCHAIN.md
@@ -25,6 +25,20 @@ Every project that ships code needs tools in these four categories:
 
 These are **categories, not brands**. The framework prescribes that you must have one in each category. It does not prescribe which one.
 
+## Conditional Categories
+
+Some categories are not universal — they apply based on project class.
+
+| Category               | What it enforces                       | When required | Examples                                            |
+| ---------------------- | -------------------------------------- | ------------- | --------------------------------------------------- |
+| **Structured logging** | Consistent, parseable telemetry output | Class 2+      | `structlog`, `tracing`, `pino`, `slog`, `swift-log` |
+
+Structured logging is not a validation gate — there is no `just log` command. It is enforced through **linter rules** that ban raw output (`print()`, `console.log()` in production code) and require use of the project's configured logger.
+
+The distinction: the four core categories produce pass/fail validation results. Structured logging shapes what code is permitted. Its enforcement is mediated through the linter — it widens the linter's mandate, not the golden command set.
+
+Construction ensures the code **produces** structured telemetry. [Delivery](../delivery/CI-CD.md#observability) ensures someone **consumes** it.
+
 ---
 
 ## Ecosystem Reference Stacks
@@ -33,54 +47,59 @@ These are examples, not mandates. Choose what fits your ecosystem and team.
 
 ### Python
 
-| Category        | Tool                | Config                                   |
-| --------------- | ------------------- | ---------------------------------------- |
-| Package manager | `uv`                | `pyproject.toml`                         |
-| Formatter       | `ruff format`       | `ruff.toml` or `pyproject.toml`          |
-| Linter          | `ruff check`        | `ruff.toml` or `pyproject.toml`          |
-| Type checker    | `mypy` or `pyright` | `pyproject.toml` or `pyrightconfig.json` |
-| Test runner     | `pytest`            | `pyproject.toml`                         |
-| Pre-commit      | `pre-commit`        | `.pre-commit-config.yaml`                |
+| Category           | Tool                     | Config                                   |
+| ------------------ | ------------------------ | ---------------------------------------- |
+| Package manager    | `uv`                     | `pyproject.toml`                         |
+| Formatter          | `ruff format`            | `ruff.toml` or `pyproject.toml`          |
+| Linter             | `ruff check`             | `ruff.toml` or `pyproject.toml`          |
+| Type checker       | `mypy` or `pyright`      | `pyproject.toml` or `pyrightconfig.json` |
+| Test runner        | `pytest`                 | `pyproject.toml`                         |
+| Structured logging | `structlog` or `logging` | logging config in app                    |
+| Pre-commit         | `pre-commit`             | `.pre-commit-config.yaml`                |
 
 ### Rust
 
-| Category        | Tool          | Config                        |
-| --------------- | ------------- | ----------------------------- |
-| Package manager | `cargo`       | `Cargo.toml`                  |
-| Formatter       | `rustfmt`     | `rustfmt.toml`                |
-| Linter          | `clippy`      | `clippy.toml` or `Cargo.toml` |
-| Type checker    | Rust compiler | Built-in                      |
-| Test runner     | `cargo test`  | Built-in                      |
+| Category           | Tool          | Config                        |
+| ------------------ | ------------- | ----------------------------- |
+| Package manager    | `cargo`       | `Cargo.toml`                  |
+| Formatter          | `rustfmt`     | `rustfmt.toml`                |
+| Linter             | `clippy`      | `clippy.toml` or `Cargo.toml` |
+| Type checker       | Rust compiler | Built-in                      |
+| Test runner        | `cargo test`  | Built-in                      |
+| Structured logging | `tracing`     | `Cargo.toml`                  |
 
 ### TypeScript
 
-| Category        | Tool               | Config                                 |
-| --------------- | ------------------ | -------------------------------------- |
-| Package manager | `pnpm` or `npm`    | `package.json`                         |
-| Formatter       | `prettier`         | `.prettierrc`                          |
-| Linter          | `eslint`           | `eslint.config.js`                     |
-| Type checker    | `tsc`              | `tsconfig.json`                        |
-| Test runner     | `vitest` or `jest` | `vitest.config.ts` or `jest.config.ts` |
+| Category           | Tool                | Config                                 |
+| ------------------ | ------------------- | -------------------------------------- |
+| Package manager    | `pnpm` or `npm`     | `package.json`                         |
+| Formatter          | `prettier`          | `.prettierrc`                          |
+| Linter             | `eslint`            | `eslint.config.js`                     |
+| Type checker       | `tsc`               | `tsconfig.json`                        |
+| Test runner        | `vitest` or `jest`  | `vitest.config.ts` or `jest.config.ts` |
+| Structured logging | `pino` or `winston` | logger config module                   |
 
 ### Swift
 
-| Category        | Tool                      | Config           |
-| --------------- | ------------------------- | ---------------- |
-| Package manager | Swift Package Manager     | `Package.swift`  |
-| Formatter       | `swift-format`            | `.swift-format`  |
-| Linter          | `swiftlint`               | `.swiftlint.yml` |
-| Type checker    | Swift compiler            | Built-in         |
-| Test runner     | `XCTest` or Swift Testing | Built-in         |
+| Category           | Tool                      | Config           |
+| ------------------ | ------------------------- | ---------------- |
+| Package manager    | Swift Package Manager     | `Package.swift`  |
+| Formatter          | `swift-format`            | `.swift-format`  |
+| Linter             | `swiftlint`               | `.swiftlint.yml` |
+| Type checker       | Swift compiler            | Built-in         |
+| Test runner        | `XCTest` or Swift Testing | Built-in         |
+| Structured logging | `swift-log` (`Logging`)   | `Package.swift`  |
 
 ### Go
 
-| Category        | Tool                  | Config          |
-| --------------- | --------------------- | --------------- |
-| Package manager | `go mod`              | `go.mod`        |
-| Formatter       | `gofmt` / `goimports` | Built-in        |
-| Linter          | `golangci-lint`       | `.golangci.yml` |
-| Type checker    | Go compiler           | Built-in        |
-| Test runner     | `go test`             | Built-in        |
+| Category           | Tool                     | Config          |
+| ------------------ | ------------------------ | --------------- |
+| Package manager    | `go mod`                 | `go.mod`        |
+| Formatter          | `gofmt` / `goimports`    | Built-in        |
+| Linter             | `golangci-lint`          | `.golangci.yml` |
+| Type checker       | Go compiler              | Built-in        |
+| Test runner        | `go test`                | Built-in        |
+| Structured logging | `slog` (stdlib) or `zap` | logger init     |
 
 ---
 
@@ -118,14 +137,16 @@ Pre-commit hooks are a convenience, not a security boundary. CI remains the auth
 
 ## When to Add vs. When to Skip
 
-| Project Class              | Formatter | Linter   | Type Checker | Test Runner |
-| -------------------------- | --------- | -------- | ------------ | ----------- |
-| **0 — Scratchpad**         | Yes       | Optional | Optional     | Optional    |
-| **1 — Prototype**          | Yes       | Yes      | Optional     | Yes         |
-| **2 — Product Seed**       | Yes       | Yes      | Yes          | Yes         |
-| **3 — Long-Lived Product** | Yes       | Yes      | Yes          | Yes         |
+| Project Class              | Formatter | Linter   | Type Checker | Test Runner | Structured Logging |
+| -------------------------- | --------- | -------- | ------------ | ----------- | ------------------ |
+| **0 — Scratchpad**         | Yes       | Optional | Optional     | Optional    | No                 |
+| **1 — Prototype**          | Yes       | Yes      | Optional     | Yes         | Optional           |
+| **2 — Product Seed**       | Yes       | Yes      | Yes          | Yes         | Yes                |
+| **3 — Long-Lived Product** | Yes       | Yes      | Yes          | Yes         | Yes                |
 
 The formatter is never optional. Consistent formatting costs nothing and prevents the most common category of noise in diffs and reviews.
+
+Structured logging becomes mandatory when the project has users (Class 2+). At that point, `print()` debugging is insufficient — you need parseable, leveled output that downstream systems can consume. For the delivery-side concern — consuming telemetry after deployment — see [Observability in CI/CD](../delivery/CI-CD.md#observability).
 
 ---
 
@@ -137,5 +158,6 @@ The toolchain exists so that neither the human nor the agent has to remember:
 - "Add type annotations"
 - "Run the tests"
 - "Follow the import order"
+- "Use the logger, not print()"
 
 These become impossible to forget — because the toolchain catches them automatically. That is the point.

--- a/src/modules/construction/VALIDATION.md
+++ b/src/modules/construction/VALIDATION.md
@@ -58,13 +58,13 @@ Running `just ci` — or its equivalent — is the gate before any PR or commit 
 
 ### What the Validation Surface Proves
 
-| Check               | What it proves                              |
-| ------------------- | ------------------------------------------- |
-| Formatter passes    | Code style is consistent                    |
-| Linter passes       | No known bad patterns, no obvious mistakes  |
-| Type checker passes | Interfaces are honored, types are sound     |
-| Tests pass          | Behavior is correct, regressions are caught |
-| Build succeeds      | The project compiles / packages correctly   |
+| Check               | What it proves                                                           |
+| ------------------- | ------------------------------------------------------------------------ |
+| Formatter passes    | Code style is consistent                                                 |
+| Linter passes       | No known bad patterns, no obvious mistakes, logging conventions enforced |
+| Type checker passes | Interfaces are honored, types are sound                                  |
+| Tests pass          | Behavior is correct, regressions are caught                              |
+| Build succeeds      | The project compiles / packages correctly                                |
 
 If all golden commands pass, the change is **mechanically valid**. It may still have design problems or incorrect logic that tests do not cover — but it has passed every automated check the project offers.
 

--- a/src/modules/delivery/CI-CD.md
+++ b/src/modules/delivery/CI-CD.md
@@ -93,6 +93,8 @@ The framework prescribes the principle, not the tooling. What matters is that th
 
 Observability is usually an afterthought — treated as something for large teams with dedicated infrastructure. But the cost of not having it shows up as debugging sessions where you are asking users to send screenshots of error messages or manually inspecting log files. Wiring basic observability early — even just structured logging and crash reporting — pays off the moment someone other than you uses the software.
 
+For construction-side observability — enforcing logging conventions during development through linter rules — see [Toolchain — Conditional Categories](../construction/TOOLCHAIN.md#conditional-categories). Construction ensures the code **produces** structured telemetry. Delivery ensures someone **consumes** it.
+
 ---
 
 ## Infrastructure as Code


### PR DESCRIPTION
## Summary

- Adds **Conditional Categories** as a new concept in the toolchain, distinct from the four core validation categories (formatter, linter, type checker, test runner)
- Structured logging is the first conditional category — mandatory for Class 2+, enforced through linter rules, no separate golden command
- Fills the gap where an agent could use `print()` in production code and violate no construction constraint
- Cross-references construction-side observability (convention enforcement) with the existing delivery-side observability section in CI-CD.md

## Files changed

- `src/modules/construction/TOOLCHAIN.md` — new Conditional Categories section, ecosystem stacks updated, class requirements table updated, Goal section updated
- `src/GLOSSARY.md` — new Structured Logging entry, Toolchain definition expanded
- `src/modules/construction/README.md` — bootstrap sequence and key principles updated
- `src/modules/construction/VALIDATION.md` — linter row expanded to include logging conventions
- `src/ADAPTING.md` — tier summary and project class tables updated
- `src/modules/delivery/CI-CD.md` — cross-reference to construction-side observability
- `src/QUICKSTART-AUDIT.md` — audit prompt construction line updated

## Test plan

- [x] `just ci` passes (fmt + lint + build)
- [ ] Spot-check rendered site for table formatting and cross-reference links

Closes #51