### PR TITLE
Add CI workflow structure and config linting guidance

### DIFF
--- a/src/modules/construction/TOOLCHAIN.md
+++ b/src/modules/construction/TOOLCHAIN.md
@@ -29,15 +29,31 @@ These are **categories, not brands**. The framework prescribes that you must hav
 
 Some categories are not universal — they apply based on project class.
 
-| Category               | What it enforces                       | When required | Examples                                            |
-| ---------------------- | -------------------------------------- | ------------- | --------------------------------------------------- |
-| **Structured logging** | Consistent, parseable telemetry output | Class 2+      | `structlog`, `tracing`, `pino`, `slog`, `swift-log` |
+| Category               | What it enforces                         | When required | Examples                                            |
+| ---------------------- | ---------------------------------------- | ------------- | --------------------------------------------------- |
+| **Structured logging** | Consistent, parseable telemetry output   | Class 2+      | `structlog`, `tracing`, `pino`, `slog`, `swift-log` |
+| **Config linting**     | CI and infrastructure config correctness | Class 2+      | `yamllint`, `actionlint`, `gitlab-ci-lint`          |
+
+### Structured Logging
 
 Structured logging is not a validation gate — there is no `just log` command. It is enforced through **linter rules** that ban raw output (`print()`, `console.log()` in production code) and require use of the project's configured logger.
 
 The distinction: the four core categories produce pass/fail validation results. Structured logging shapes what code is permitted. Its enforcement is mediated through the linter — it widens the linter's mandate, not the golden command set.
 
 Construction ensures the code **produces** structured telemetry. [Delivery](../delivery/CI-CD.md#observability) ensures someone **consumes** it.
+
+### Config Linting
+
+CI configuration files are code. The method's constraint-first philosophy applies to them, not just to source code. If an agent modifies a workflow file and the golden command does not catch a broken `uses:` reference, the constraint corridor has a hole.
+
+Two layers of config linting:
+
+| Layer                 | What it catches                                                       | Tool examples                                            |
+| --------------------- | --------------------------------------------------------------------- | -------------------------------------------------------- |
+| **YAML validation**   | Syntax errors, duplicate keys, indentation issues                     | `yamllint`                                               |
+| **Schema validation** | Semantic errors — invalid inputs, missing actions, broken expressions | `actionlint` (GitHub Actions), `gitlab-ci-lint` (GitLab) |
+
+Config linting **is** a validation gate. It should be included in `just lint` or exposed as `just lint-ci` — either way, it must be part of the [validation surface](VALIDATION.md). The validation surface includes configuration files, not just source code.
 
 ---
 
@@ -137,12 +153,12 @@ Pre-commit hooks are a convenience, not a security boundary. CI remains the auth
 
 ## When to Add vs. When to Skip
 
-| Project Class              | Formatter | Linter   | Type Checker | Test Runner | Structured Logging |
-| -------------------------- | --------- | -------- | ------------ | ----------- | ------------------ |
-| **0 — Scratchpad**         | Yes       | Optional | Optional     | Optional    | No                 |
-| **1 — Prototype**          | Yes       | Yes      | Optional     | Yes         | Optional           |
-| **2 — Product Seed**       | Yes       | Yes      | Yes          | Yes         | Yes                |
-| **3 — Long-Lived Product** | Yes       | Yes      | Yes          | Yes         | Yes                |
+| Project Class              | Formatter | Linter   | Type Checker | Test Runner | Structured Logging | Config Linting |
+| -------------------------- | --------- | -------- | ------------ | ----------- | ------------------ | -------------- |
+| **0 — Scratchpad**         | Yes       | Optional | Optional     | Optional    | No                 | No             |
+| **1 — Prototype**          | Yes       | Yes      | Optional     | Yes         | Optional           | Optional       |
+| **2 — Product Seed**       | Yes       | Yes      | Yes          | Yes         | Yes                | Yes            |
+| **3 — Long-Lived Product** | Yes       | Yes      | Yes          | Yes         | Yes                | Yes            |
 
 The formatter is never optional. Consistent formatting costs nothing and prevents the most common category of noise in diffs and reviews.
 
@@ -159,5 +175,6 @@ The toolchain exists so that neither the human nor the agent has to remember:
 - "Run the tests"
 - "Follow the import order"
 - "Use the logger, not print()"
+- "Validate the CI config before pushing"
 
 These become impossible to forget — because the toolchain catches them automatically. That is the point.

--- a/src/modules/construction/VALIDATION.md
+++ b/src/modules/construction/VALIDATION.md
@@ -58,13 +58,16 @@ Running `just ci` — or its equivalent — is the gate before any PR or commit 
 
 ### What the Validation Surface Proves
 
-| Check               | What it proves                                                           |
-| ------------------- | ------------------------------------------------------------------------ |
-| Formatter passes    | Code style is consistent                                                 |
-| Linter passes       | No known bad patterns, no obvious mistakes, logging conventions enforced |
-| Type checker passes | Interfaces are honored, types are sound                                  |
-| Tests pass          | Behavior is correct, regressions are caught                              |
-| Build succeeds      | The project compiles / packages correctly                                |
+| Check                 | What it proves                                                                  |
+| --------------------- | ------------------------------------------------------------------------------- |
+| Formatter passes      | Code style is consistent                                                        |
+| Linter passes         | No known bad patterns, no obvious mistakes, logging conventions enforced        |
+| Type checker passes   | Interfaces are honored, types are sound                                         |
+| Tests pass            | Behavior is correct, regressions are caught                                     |
+| Build succeeds        | The project compiles / packages correctly                                       |
+| Config linting passes | CI workflows and infrastructure config are syntactically and semantically valid |
+
+The validation surface includes configuration files, not just source code. CI workflows, Docker configs, and infrastructure-as-code should be linted with the same rigor as application code. See [Toolchain — Conditional Categories](TOOLCHAIN.md#conditional-categories) and [Infrastructure as Code](../delivery/CI-CD.md#infrastructure-as-code).
 
 If all golden commands pass, the change is **mechanically valid**. It may still have design problems or incorrect logic that tests do not cover — but it has passed every automated check the project offers.
 

--- a/src/modules/delivery/CI-CD.md
+++ b/src/modules/delivery/CI-CD.md
@@ -20,6 +20,49 @@ CI answers: **"Is this change good enough to integrate?"**
 
 ---
 
+## CI Workflow Structure
+
+> **One concern per workflow, same as one concern per golden command.**
+
+CI structure should mirror the [golden command](../construction/VALIDATION.md) structure. Each golden command maps to one validation concern. Each CI workflow should do the same.
+
+```text
+.github/workflows/
+  format.yml        # just fmt
+  lint.yml          # just lint
+  typecheck.yml     # just typecheck
+  test.yml          # just test
+  build.yml         # just build (artifact creation)
+  release.yml       # release automation
+```
+
+### Why Split
+
+A monolith workflow — one file, hundreds of lines, every check in a single job — creates the same problems as a monolith PR:
+
+- **Debugging is archaeology.** When CI fails, you dig through a wall of output to find which concern broke.
+- **Caching is coarse.** Different concerns have different dependency profiles. A format check does not need the test fixtures.
+- **Skipping is impossible.** A documentation-only change should not run the test suite. A monolith workflow runs everything or nothing.
+- **Agent maintenance is fragile.** An agent adding a new CI check to a 300-line workflow file must understand the entire file to splice correctly. A new file is self-contained.
+
+Split workflows are independently triggerable, independently debuggable, independently cacheable, and independently skippable.
+
+### Sharing Setup
+
+Split workflows often share setup steps — checkout, install dependencies, configure the runtime. The mechanism for sharing without duplication:
+
+- **GitHub Actions:** [reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows) or [composite actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)
+- **GitLab CI:** `include` templates and `extends`
+- **General:** a shared setup script that each workflow calls
+
+The principle: **share setup, not concerns.** A reusable workflow for "install Python and dependencies" is good. A reusable workflow for "run all checks" defeats the purpose of splitting.
+
+### When a Single Workflow Is Fine
+
+Class 0–1 projects where the entire CI is five lines — format, lint, test — do not benefit from splitting. The overhead of multiple files exceeds the complexity of the pipeline. Split when the pipeline outgrows a single screen.
+
+---
+
 ## CD Is About Movement
 
 CD answers: **"Can we safely move this artifact through environments and channels?"**


### PR DESCRIPTION
## Summary

- Adds **CI Workflow Structure** section to CI-CD.md — one concern per workflow, mirroring the golden command structure. Covers why to split monolith workflows, how to share setup via reusable workflows/composite actions, and when a single workflow is acceptable (Class 0–1).
- Adds **Config Linting** as a conditional toolchain category in TOOLCHAIN.md — `yamllint` for YAML syntax, `actionlint` for GitHub Actions semantics. Unlike structured logging, config linting *is* a validation gate and should be part of `just lint` or `just lint-ci`.
- Updates the validation surface in VALIDATION.md to include config linting as a check, with a statement that the validation surface covers configuration files, not just source code.

## Files changed

- `src/modules/delivery/CI-CD.md` — new CI Workflow Structure section (one concern per workflow, sharing setup, when to split)
- `src/modules/construction/TOOLCHAIN.md` — config linting in conditional categories table, two-layer explanation (YAML + schema validation), class requirements table updated
- `src/modules/construction/VALIDATION.md` — config linting row in validation surface table, statement about config files as part of the surface

## Test plan

- [x] `just ci` passes (fmt + lint + build)
- [ ] Spot-check rendered site for new sections and table formatting

Closes #52, closes #53